### PR TITLE
Fixed form-control classes with checkboxes

### DIFF
--- a/crispy_bootstrap3/templates/bootstrap3/field.html
+++ b/crispy_bootstrap3/templates/bootstrap3/field.html
@@ -25,11 +25,15 @@
         {% endif %}
 
         {% if not field|is_checkboxselectmultiple and not field|is_radioselect %}
-            {% if field|is_checkbox and form_show_labels %}
-                <label for="{{ field.id_for_label }}" class="{% if field.field.required %} requiredField{% endif %}">
+            {% if field|is_checkbox %}
+                {% if form_show_labels %}
+                    <label for="{{ field.id_for_label }}" class="{% if field.field.required %} requiredField{% endif %}">
+                        {% crispy_field field %}
+                        {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
+                    </label>
+                {% else %}
                     {% crispy_field field %}
-                    {{ field.label }}{% if field.field.required %}<span class="asteriskField">*</span>{% endif %}
-                </label>
+                {% endif %}
                 {% include 'bootstrap3/layout/help_text_and_errors.html' %}
             {% else %}
                 <div class="controls {{ field_class }}">

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -82,6 +82,12 @@ class CheckboxesSampleForm(forms.Form):
     )
 
 
+class SimpleCheckboxSampleForm(forms.Form):
+    is_company = forms.CharField(
+        label="company", required=False, widget=forms.CheckboxInput()
+    )
+
+
 class SelectSampleForm(forms.Form):
     select = forms.ChoiceField(
         choices=((1, "Option one"), (2, "Option two"), (3, "Option three")),

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -35,6 +35,7 @@ from .forms import (
     SampleForm4,
     SampleForm5,
     SampleForm6,
+    SimpleCheckboxSampleForm,
 )
 from .test_settings import TEMPLATE_DIRS
 from .utils import contains_partial, parse_expected, parse_form
@@ -584,6 +585,19 @@ def test_multiple_checkboxes_bs3():
     assert parse_form(form) == parse_expected(
         "bootstrap3/test_layout/test_multiple_checkboxes.html"
     )
+
+
+def test_no_label_checkboxes_bs3():
+    form = SimpleCheckboxSampleForm()
+    form.helper = FormHelper()
+    # no form-control class when labels are rendered
+    html = render_crispy_form(form)
+    assert html.count("form-control") == 0
+    form.helper.form_show_labels = False
+    # no labels or form-control class when labels are hidden
+    html = render_crispy_form(form)
+    assert html.count("<label ") == 0
+    assert html.count("form-control") == 0
 
 
 @pytest.mark.skipif(__version__[0] == "1", reason="#1262 fixed required attributes.")


### PR DESCRIPTION
handle case where checkbox is rendered without label.

regression test added: test fails for ver. 2022.1 passes with this fix.